### PR TITLE
デフォルトでexportしているLDFLAGSの値がgoビルド時になるので修正

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -103,7 +103,7 @@ export PATH="$HOME/.cargo/bin:$PATH"
 case ${OSTYPE} in
   darwin*)
     export PATH="/usr/local/opt/opencv3/bin:$PATH"
-    export LDFLAGS="-L/usr/local/opt/readline/lib";
+    #export LDFLAGS="-L/usr/local/opt/readline/lib";
     export CPPFLAGS="-I/usr/local/opt/readline/include";
     export PATH=/usr/local/opt/qt5/bin:$PATH
     export PKG_CONFIG_PATH="/usr/local/opt/readline/lib/pkgconfig";
@@ -121,7 +121,7 @@ esac
 case ${OSTYPE} in
   darwin*)
     export PATH="/usr/local/opt/mysql-client/bin:$PATH";
-    export LDFLAGS="-L/usr/local/opt/mysql-client/lib";
+    #export LDFLAGS="-L/usr/local/opt/mysql-client/lib";
     export CPPFLAGS="-I/usr/local/opt/mysql-client/include";
     export PKG_CONFIG_PATH="/usr/local/opt/mysql-client/lib/pkgconfig";
     export PATH="/opt/homebrew/opt/libpq/bin:$PATH";
@@ -130,6 +130,8 @@ case ${OSTYPE} in
   linux*)
     ;;
 esac
+
+export LDFLAGS="-s -w";
 
 source "$HOME/kube-ps1/kube-ps1.sh"
 PS1='$(kube_ps1)'$PS1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Disabled previous linker flags for `readline` and `mysql-client` to improve compatibility on Darwin operating systems.
  
- **New Features**
	- Introduced new linker flags to optimize builds and reduce binary size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->