### PR TITLE
MySQLクライアントのバージョンを明示的に8.0系にするように変更

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -120,7 +120,7 @@ esac
 
 case ${OSTYPE} in
   darwin*)
-    export PATH="/usr/local/opt/mysql-client/bin:$PATH";
+    export PATH="/opt/homebrew/opt/mysql-client@8.0/bin:$PATH"
     #export LDFLAGS="-L/usr/local/opt/mysql-client/lib";
     export CPPFLAGS="-I/usr/local/opt/mysql-client/include";
     export PKG_CONFIG_PATH="/usr/local/opt/mysql-client/lib/pkgconfig";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the MySQL client path to ensure compatibility with the latest Homebrew versioning system on macOS.

- **Bug Fixes**
	- Corrected the environment variable configuration to reflect the new installation location of the MySQL client, enhancing accessibility for scripts and commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->