### PR TITLE
Add flush-dns alias

### DIFF
--- a/zshrc.extra.commands
+++ b/zshrc.extra.commands
@@ -12,3 +12,5 @@ peco-select-history() {
 }
 zle -N peco-select-history
 bindkey '^r' peco-select-history
+
+alias flush-dns='sudo killall -HUP mDNSResponder'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new alias, `flush-dns`, to quickly flush the DNS cache on macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->