### PR TITLE
Add aliases, completions

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -161,3 +161,5 @@ fpath=($HOME/.docker/completions $fpath)
 autoload -Uz compinit
 compinit
 # End of Docker CLI completions
+
+[[ "$TERM_PROGRAM" == "kiro" ]] && . "$(kiro --locate-shell-integration-path zsh)"

--- a/zshrc.alias.sh
+++ b/zshrc.alias.sh
@@ -31,6 +31,9 @@ alias docker-rmi-all='sudo docker rmi $(sudo docker images --format "{{.Reposito
 # Kubernetes
 alias k='kubectl'
 
+# kubectl-ai
+alias kai='kubectl-ai'
+
 # Multipass
 alias mlp='multipass'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically loads KiRO-specific Zsh integration when running in the KiRO terminal (TERM_PROGRAM=kiro), enhancing the shell experience while leaving other environments unchanged.
  - Introduces a convenient kai alias for kubectl-ai in the Kubernetes tooling, enabling faster access to AI-assisted kubectl commands and improving workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->