### PR TITLE
Change mysql-client path

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -131,7 +131,6 @@ esac
 
 case ${OSTYPE} in
   darwin*)
-    #export PATH="/opt/homebrew/opt/mysql-client@8.0/bin:$PATH"
     export PATH="/opt/homebrew/opt/mysql-client/bin:$PATH"
     #export LDFLAGS="-L/usr/local/opt/mysql-client/lib";
     export CPPFLAGS="-I/usr/local/opt/mysql-client/include";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS environment configuration to point to the Homebrew-installed MySQL client, ensuring the correct client is used by shell sessions and improving command accessibility and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->