### PR TITLE
Fix shell env manager initialization

### DIFF
--- a/install_phpenv
+++ b/install_phpenv
@@ -1,7 +1,28 @@
 #!/usr/bin/env zsh
 
-git clone https://github.com/phpenv/phpenv.git ~/.phpenv
-git clone https://github.com/php-build/php-build.git $HOME/.phpenv/plugins/php-build
+append_line_once() {
+  local file="$1"
+  local line="$2"
 
-echo 'export PATH="$HOME/.phpenv/bin:$PATH"' >> ~/.profile
-echo 'eval "$(phpenv init -)"' >> ~/.profile
+  touch "$file"
+  grep -qxF -- "$line" "$file" || print -r -- "$line" >> "$file"
+}
+
+git clone https://github.com/phpenv/phpenv.git "$HOME/.phpenv"
+git clone https://github.com/php-build/php-build.git "$HOME/.phpenv/plugins/php-build"
+
+startup_files=( "$HOME/.profile" )
+case "${SHELL:-}" in
+  *zsh) startup_files+=( "$HOME/.zshrc" ) ;;
+esac
+
+phpenv_init_lines=(
+  'export PATH="$HOME/.phpenv/bin:$PATH"'
+  'eval "$(phpenv init -)"'
+)
+
+for startup_file in "${startup_files[@]}"; do
+  for init_line in "${phpenv_init_lines[@]}"; do
+    append_line_once "$startup_file" "$init_line"
+  done
+done

--- a/zshrc
+++ b/zshrc
@@ -75,6 +75,11 @@ man() {
         man "$@"
 }
 
+if [ -x "$HOME/.phpenv/bin/phpenv" ]; then
+  export PATH="$HOME/.phpenv/bin:$PATH"
+  eval "$("$HOME/.phpenv/bin/phpenv" init - zsh)"
+fi
+
 export PATH="$HOME/local/bin:$PATH"
 if [ -x "/opt/homebrew/bin/rbenv" ]; then
   eval "$(/opt/homebrew/bin/rbenv init - zsh)"
@@ -83,10 +88,16 @@ elif [ -x "/usr/local/bin/rbenv" ]; then
 elif [ -x "$HOME/.rbenv/bin/rbenv" ]; then
   export PATH="$HOME/.rbenv/bin:$PATH"
   eval "$("$HOME/.rbenv/bin/rbenv" init - zsh)"
+elif [ -d "$HOME/.rbenv" ] && command -v rbenv >/dev/null 2>&1; then
+  eval "$(RBENV_ROOT="$HOME/.rbenv" rbenv init - zsh)"
 fi
 
-export PATH="$HOME/.pyenv/bin:$PATH"
-eval "$(pyenv init --path --no-rehash)"
+if [ -x "$HOME/.pyenv/bin/pyenv" ]; then
+  export PATH="$HOME/.pyenv/bin:$PATH"
+fi
+if command -v pyenv >/dev/null 2>&1; then
+  eval "$(pyenv init --path --no-rehash)"
+fi
 
 if [ -e "~/perl5/perlbrew/etc/bashrc" ]; then
   source ~/perl5/perlbrew/etc/bashrc
@@ -103,8 +114,12 @@ test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell
 export GOENV_ROOT="$HOME/.goenv"
 export GOENV_DISABLE_GOROOT=1
 unset GOROOT
-export PATH="$GOENV_ROOT/bin:$PATH"
-eval "$(goenv init -)"
+if [ -x "$GOENV_ROOT/bin/goenv" ]; then
+  export PATH="$GOENV_ROOT/bin:$PATH"
+fi
+if command -v goenv >/dev/null 2>&1; then
+  eval "$(goenv init -)"
+fi
 
 # Go Modules使用時のデフォルト設定
 # GOPATH は Go Modules プロジェクト外でのみ使用される

--- a/zshrc
+++ b/zshrc
@@ -96,7 +96,7 @@ if [ -x "$HOME/.pyenv/bin/pyenv" ]; then
   export PATH="$HOME/.pyenv/bin:$PATH"
 fi
 if command -v pyenv >/dev/null 2>&1; then
-  eval "$(pyenv init --path --no-rehash)"
+  eval "$(pyenv init - --no-rehash zsh)"
 fi
 
 if [ -e "~/perl5/perlbrew/etc/bashrc" ]; then
@@ -111,14 +111,17 @@ PS1="$PS1"'$([ -n "$TMUX" ] && tmux setenv TMUXPWD_$(tmux display -p "#D" | tr -
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
 
 # Go環境設定 (goenv + Go Modules)
-export GOENV_ROOT="$HOME/.goenv"
-export GOENV_DISABLE_GOROOT=1
-unset GOROOT
-if [ -x "$GOENV_ROOT/bin/goenv" ]; then
+if [ -x "$HOME/.goenv/bin/goenv" ]; then
+  export GOENV_ROOT="$HOME/.goenv"
+  export GOENV_DISABLE_GOROOT=1
+  unset GOROOT
   export PATH="$GOENV_ROOT/bin:$PATH"
-fi
-if command -v goenv >/dev/null 2>&1; then
-  eval "$(goenv init -)"
+  eval "$("$GOENV_ROOT/bin/goenv" init - zsh)"
+elif command -v goenv >/dev/null 2>&1; then
+  export GOENV_ROOT="${GOENV_ROOT:-$HOME/.goenv}"
+  export GOENV_DISABLE_GOROOT=1
+  unset GOROOT
+  eval "$(goenv init - zsh)"
 fi
 
 # Go Modules使用時のデフォルト設定


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell startup reliability by initializing language/version managers (PHP, Ruby, Python, Go) only when their tools are present, preventing errors and startup noise.

* **Chores**
  * Hardened shell configuration to set PATH and environment entries conditionally, reducing unnecessary initialization and improving robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->